### PR TITLE
fix bad CSV syntax

### DIFF
--- a/DefaultCreds-Cheat-Sheet.csv
+++ b/DefaultCreds-Cheat-Sheet.csv
@@ -29,9 +29,9 @@
  Schneider M340(Web),USER,USER
  Schneider Premium(FTP),sysdiag,factorycast@schneider
  Schneider Premium(WEB),USER,USER
- Siemens S7-1200(Web),admin,,
+ Siemens S7-1200(Web),admin,
  Yealink,admin,admin
- Snom,admi,,
+ Snom,admi,
  Sonus,admin,Sonus12345
  Grandstream,admin,admin
  Asterisk,Admin,admin


### PR DESCRIPTION
I had an error parsing the new version of the CSV after https://github.com/ihebski/DefaultCreds-cheat-sheet/commit/98e19f1ad2b7a7a20ff2fecdf8c1503716720df4

In the new ICS entries you added for #6 two have 4 columns instead of 3. For my CSV parser is was creating a null column that was making my program crash.

Github also detect an error: 
![image](https://user-images.githubusercontent.com/16578570/109789962-27dcc480-7c11-11eb-8f69-6eed9d8bd239.png)


