### PR TITLE
Add default creds for Gitlab

### DIFF
--- a/DefaultCreds-Cheat-Sheet.csv
+++ b/DefaultCreds-Cheat-Sheet.csv
@@ -1032,6 +1032,9 @@ Gigabyte,admin,admin
 GigaFiber,admin,jiocentrum
 glftpd,glftpd,glftpd
 glFtpD,glftpd,glftpd
+Gitlab,admin,5iveL!fe
+Gitlab,admin@local.host,5iveL!fe
+Gitlab,root,5iveL!fe
 Globespan Virata,DSL,DSL
 GlobespanVirata,root,root
 Google,admin,urchin


### PR DESCRIPTION
Default creds for Gitlab instance, check the following link: https://gitlab.com/gitlab-org/gitlab-development-kit/-/blob/c82f5c4ba003d395d5d59c925c8931a0b9491b20/doc/set-up-gdk.md#L164