### PR TITLE
Remove "hashlib": already in standard library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests
 prettytable
 fire
 pathlib
-hashlib


### PR DESCRIPTION
https://docs.python.org/3/library/hashlib.html