### PR TITLE
Fix AttributeError when `keyword` is an integer

### DIFF
--- a/creds
+++ b/creds
@@ -97,9 +97,9 @@ def search(keyword,export=False):
     """
     if len(db.all()) == 0:
         get_db()
-        print_table(db.search(where("product").search(keyword.lower())),keyword,export)
+        print_table(db.search(where("product").search(str(keyword).lower())),keyword,export)
     else:
-        print_table(db.search(where("product").search(keyword.lower())),keyword,export)
+        print_table(db.search(where("product").search(str(keyword).lower())),keyword,export)
 
 def sha256sum(filename):
     """


### PR DESCRIPTION
Description:
The current implementation encounters an `AttributeError` when attempting to call the `lower()` method on the `keyword` variable, assuming it is a string. However, if `keyword` happens to be an integer, this attribute does not exist.

To fix this issue, I have added a conversion step to ensure that `keyword` is treated as a string. By using the `str()` function to convert `keyword` to a string before calling `lower()`, we can avoid the `AttributeError` and allow the program to proceed correctly.

Changes Made:
- Added a conversion step to ensure `keyword` is treated as a string before calling `lower()`.

Testing:
I have tested this fix with various inputs, including both string and integer values for `keyword`, and confirmed that the `AttributeError` no longer occurs. The program now executes as expected and provides the desired output.

I kindly request a review and merge of this pull request. Thank you!