### PR TITLE
Update DefaultCreds-Cheat-Sheet.csv

### DIFF
--- a/DefaultCreds-Cheat-Sheet.csv
+++ b/DefaultCreds-Cheat-Sheet.csv
@@ -565,6 +565,7 @@ Chase Research,<blank>,iolan
 Checkpoint,admin,abc123
 Checkpoint,admin,admin
 Check Point,admin,admin
+Check Point 1470 appliance,admin,Admin123
 Check Point,admin,adminadmin
 Checkpoint (web),admin,abc123
 Checkpoint (web),admin,admin


### PR DESCRIPTION
Added Checkpoint 1470 appliance creds. No longer sold but used by some orgs.