### PR TITLE
Remove pathlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ tinydb==4.3
 requests
 prettytable
 fire
-pathlib


### PR DESCRIPTION
`pathlib` is a [standard module](https://docs.python.org/3/library/pathlib.html) for Python > 3.4.