### PR TITLE
Typo fix for #68

### DIFF
--- a/DefaultCreds-Cheat-Sheet.csv
+++ b/DefaultCreds-Cheat-Sheet.csv
@@ -2073,7 +2073,7 @@ OPEN Networks,root,0P3N
 Openwave,cac_admin,cacadmin
 Openwave,sys,uplink
 Open-Xchange Inc.,mailadmin,secret
-OPNSence,root,opnsense
+OPNSense,root,opnsense
 OptiLink,e8c,e8c
 Optivision,root,mpegvideo
 Oracle,ADAMS,WOOD


### PR DESCRIPTION
Fixed typo for #68 `OPNSence` should be `OPNsense` - https://opnsense.org/