### PR TITLE
feat(arcane): adding default Arcane credential

### DIFF
--- a/DefaultCreds-Cheat-Sheet.csv
+++ b/DefaultCreds-Cheat-Sheet.csv
@@ -258,6 +258,7 @@ Apple,root,admin
 Apple,root,alpine
 Applied Innovations,scout,scout
 ArangoDB (web),root,<blank>
+Arcane,arcane,arcane-admin
 Areca,admin,0
 arecont (web),admin,<blank>
 arecont (web),<blank>,<blank>


### PR DESCRIPTION
Greetings,

First of all thank you for this very useful project.

This PR aims to add a new default credential for the Arcane project (https://github.com/getarcaneapp/arcane), the default credential is documented here: https://getarcane.app/docs/setup/installation.

Regards.