### PR TITLE
feat(multiOTP): add multiOTP default credential

### DIFF
--- a/DefaultCreds-Cheat-Sheet.csv
+++ b/DefaultCreds-Cheat-Sheet.csv
@@ -1928,6 +1928,7 @@ MSSQL (mssql),sa,sa
 MSSQL (mssql),sa,sqlserver
 M Technology,<blank>,mMmM
 MTNL,admin,admin
+multiOTP,admin,1234
 Mutare,<blank>,admin
 Muze,admin,muze
 MyioSoft,demo,demo


### PR DESCRIPTION
Greetings,

This PR aims to add a new default credential for the multiOTP (https://multiotp.com/) product, the default credential is documented here: https://download.multiotp.com/documentation/multiOTP_Pro_and_Enterprise_Quick_Start.pdf

Regards.