### PR TITLE
Fix setuptools package discovery for Git installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setup(name='default-creds',
     description='One place for all the default credentials to assist pentesters during an engagement, this document has several products default login/password gathered from multiple sources.',
     url='https://github.com/ihebski/DefaultCreds-cheat-sheet.git',
     install_requires=install_requires,
-    scripts=['creds']
+    scripts=['creds'],
+    packages=[]
 )


### PR DESCRIPTION
Hello,

It looks like a recent repository layout change may have broken installs from Git using tools such as `pipx` or `uv`.

For example:

```shell
pipx install git+https://github.com/ihebski/DefaultCreds-cheat-sheet.git
```
currently fails with:
```shell
error: Multiple top-level packages discovered in a flat-layout: ['sc', 'ssh_keys'].
```

**Proposed fix**

Explicitly set `packages=[]` in `setup.py`, which prevents setuptools from treating non-package top-level directories such as `sc` and `ssh_keys` as Python packages during Git-based installs.

This fixes the issue with `pipx` and `uv`.